### PR TITLE
[blog] Add MindSpore HyperParallel RoadMap for LlamaFactory

### DIFF
--- a/content/posts/mindspore-hyperparallel-roadmap.en.md
+++ b/content/posts/mindspore-hyperparallel-roadmap.en.md
@@ -1,0 +1,137 @@
+---
+date: '2026-03-30T15:42:54+08:00'
+draft: false
+title: 'LlamaFactory x MindSpore HyperParallel Community Collaboration Roadmap'
+---
+
+> **MindSpore Community** · HyperParallel SuperNode Parallel Library
+>
+> Version: v1.0 | Updated: 2026-03-30
+
+## Vision
+
+HyperParallel is a new supernode parallel training architecture proposed by the **MindSpore Community**, dedicated to simplifying Ascend supernode programming and unlocking computing potential. We aim to collaborate with the LlamaFactory ecosystem to provide an easy-to-use, high-performance distributed training solution. Our goal is to enable every developer to efficiently train large models on Ascend NPU and NVIDIA GPU, lowering the barrier and cost of large model training.
+
+This roadmap outlines the development direction of the LlamaFactory and MindSpore HyperParallel community collaboration, covering parallel capability expansion, hardware optimization, backend support, and more.
+
+## Roadmap Overview
+
+```
+2026 Q2                    2026 Q3                    2026 Q4
+    │                          │                          │
+    ▼                          ▼                          ▼
+┌─────────────┐          ┌─────────────┐          ┌─────────────┐
+│  Phase 1    │          │  Phase 2    │          │  Phase 3    │
+│  Capability │   ───►   │  Hardware   │   ───►   │  Backend    │
+│  Expansion  │          │  Deepening  │          │  Diversity  │
+└─────────────┘          └─────────────┘          └─────────────┘
+    │                          │                          │
+    ├─ TP/EP/CP Hybrid         ├─ High-Dim TP             ├─ MindSpore Backend
+    ├─ More Model Coverage     ├─ HyperMPMD 3-Level       ├─ Graph-Kernel Fusion
+    └─ Larger Model Scale      └─ HyperOffload UD-Chain   └─ More Training Stages
+```
+
+## Phase 1: Parallel Capability Expansion (2026 Q2)
+
+**Goal**: Extend multi-dimensional hybrid parallel capabilities including TP (Tensor Parallelism), EP (Expert Parallelism), and CP (Context Parallelism) to support larger-scale model training.
+
+| Feature | Description | Priority | Status |
+|---------|-------------|----------|--------|
+| **TP-EP Hybrid** | Support TP+EP combined parallelism for MoE models | P0 | Validating |
+| **CP Long Sequence** | Context parallelism to break memory limits for ultra-long sequences | P0 | Validating |
+| **3D Parallel (DP-TP-PP)** | Full 3D hybrid parallelism for 100B+ parameter models | P1 | Validating |
+| **Ascend-Affinity Offload** | NPU-affinity multi-level intelligent memory offload strategies | P2 | In Development |
+
+**Key Technical Points**:
+- Unified declarative parallel strategy configuration interface
+- Efficient communication primitives and scheduling algorithms
+- Ascend-affinity parallel and memory strategies
+
+## Phase 2: Ascend Hardware Deep Optimization (2026 Q3)
+
+### 2.1 High-Dimensional Tensor Parallelism (High-Dimensional TP)
+
+**Goal**: Extend high-dimensional TP and other Ascend-affinity parallel features to improve training efficiency and generalization on Atlas A5/A3/A2.
+
+| Feature | Description | Hardware | Expected Benefit |
+|---------|-------------|----------|-----------------|
+| **2D-TP** | Two-dimensional tensor parallelism to reduce communication overhead; benefits grow significantly when TP ≥ 8 | A5/A3 | Communication reduced by 30%+ (even better at TP ≥ 8) |
+| **TP-PP Hybrid** | TP + Pipeline Parallelism combination | A5/A3/A2 | Memory optimization 20%+ |
+
+> **Note**: The communication optimization of high-dimensional TP becomes increasingly significant as TP parallelism degree grows—when TP ≥ 8, the All-Reduce communication volume of traditional 1D-TP becomes a major bottleneck. 2D-TP splits communication across two dimensions, reducing communication volume by over 40% compared to 1D-TP.
+
+### 2.2 MPMD Multi-Core Parallel Optimization (HyperMPMD)
+
+**Goal**: Leverage fine-grained MPMD (Multiple Program Multiple Data) parallelism to address computational load imbalance in MoE, multimodal, and reinforcement learning scenarios, fully utilizing the peer-to-peer interconnect architecture of Ascend supernodes.
+
+HyperMPMD provides MPMD capabilities across three dimensions:
+
+**Dimension 1: Intra-sub-model Core-Level Concurrency**
+
+Leveraging the heterogeneous multi-core AICube/AIVector architecture on Ascend NPUs to achieve fine-grained compute-communication pipelining within a single card, addressing the communication masking challenge in MoE architectures.
+
+| Feature | Description | Hardware | Expected Benefit |
+|---------|-------------|----------|-----------------|
+| **On-chip Multi-core MPMD** | AICube handles matrix ops, AIVector handles communication preprocessing, both pipelined in parallel | A5/A3 | Communication masking ratio from 60% to **90%** |
+
+**Dimension 2: Inter-sub-model Concurrency Balancing**
+
+Decoupling heterogeneous sub-modules (e.g., text/image/audio encoders in multimodal models) into independent concurrent subgraph tasks, eliminating pipeline bubbles through dynamic scheduling.
+
+**Dimension 3: Cross-model Concurrent Scheduling**
+
+Integrating the MPMD runtime's Single Controller mode to enable model-level concurrency within the supernode's pooled computing resources, supporting the asynchronous architecture of reinforcement learning.
+
+**Expected Benefits**:
+- Communication masking ratio from **60% → 90%**
+- Eliminate **10-40%** pipeline bubbles in multimodal/MoE scenarios
+- Overall training performance improvement of approximately **15%**, cluster resource utilization improvement of **15%+**
+
+### 2.3 Intelligent Memory Offloading (HyperOffload)
+
+**Goal**: Based on Use-Definition (UD) chain analysis, elevate remote memory access to a first-class operation in the computation graph, achieving deterministic global memory planning and compute-communication overlap, fully releasing the potential of the supernode's hierarchical storage pool.
+
+**Technical Approach**: HyperOffload performs global lifetime analysis of tensor definition points and use points through the compiler's Use-Definition chain, precisely identifying the optimal offload/prefetch timing for each tensor. It goes beyond traditional weight-only offloading to enable deep hierarchical management of KV Cache, intermediate activations, and optimizer states throughout the training and inference pipeline. Through a UD chain-driven unified logical view, it automatically detects bandwidth differences between HBM and DDR based on hardware topology, seamlessly scheduling massive tensors across storage tiers.
+
+**Expected Benefits** (based on HyperOffload paper experimental data):
+
+*Training Scenarios*:
+| Model | Hardware Config | Baseline | + HyperOffload | Performance Change |
+|-------|----------------|----------|----------------|--------------------|
+| LLaMA-8B | 8×Ascend 910C | 5.2s/step | 4.08s/step | **~20% improvement** |
+| DeepSeek-V3 | 8×Ascend 910C | 2.5s/step | 2.19s/step | **~12% improvement** |
+
+## Phase 3: MindSpore Backend Support (2026 Q4)
+
+**Goal**: LlamaFactory officially supports MindSpore backend, enabling AKG, DVM and other MindSpore-exclusive deep graph-kernel fusion optimization capabilities, further unlocking Ascend NPU computing power.
+
+## Community Collaboration Plan
+
+### Collaboration with LlamaFactory Community
+
+| Area | Details | Responsible |
+|------|---------|-------------|
+| **Code Integration** | LlamaFactory officially supports MindSpore backend, integrating HyperParallel parallel capabilities | Co-built |
+| **Documentation** | Add MindSpore backend user guide to LlamaFactory official documentation | Co-built |
+| **Issue Handling** | Establish joint issue handling mechanism | Co-built |
+| **Version Sync** | Ensure HyperParallel and LlamaFactory version compatibility | Co-built |
+
+## Contact Us
+
+- **MindSpore HyperParallel Repository**: https://atomgit.com/mindspore/hyper-parallel
+- **MindSpore Official Website**: https://www.mindspore.cn/
+- **MindSpore Community**: https://gitcode.com/mindspore
+
+## Appendix: Glossary
+
+| Term | Full Name | Description |
+|------|-----------|-------------|
+| TP | Tensor Parallelism | Tensor Parallelism |
+| EP | Expert Parallelism | Expert Parallelism |
+| CP | Context Parallelism | Long Sequence Parallelism |
+| DP | Data Parallelism | Data Parallelism |
+| PP | Pipeline Parallelism | Pipeline Parallelism |
+| FSDP | Fully Sharded Data Parallel | Fully Sharded Data Parallelism |
+| SPMD | Single Program Multiple Data | Single Program Multiple Data |
+| MPMD | Multiple Program Multiple Data | Multiple Program Multiple Data |
+| HCCL | Huawei Collective Communication Library | Huawei Collective Communication Library |

--- a/content/posts/mindspore-hyperparallel-roadmap.zh.md
+++ b/content/posts/mindspore-hyperparallel-roadmap.zh.md
@@ -1,0 +1,136 @@
+---
+date: '2026-03-30T15:42:54+08:00'
+draft: false
+title: 'LlamaFactory x MindSpore HyperParallel 社区协作路标'
+---
+
+> **昇思社区** · HyperParallel 超节点并行库
+>
+> 文档版本：v1.0 | 更新日期：2026-03-30
+
+## 项目愿景
+
+HyperParallel 是 **昇思社区** 新提出的超节点并行训练架构，致力于简化昇腾超节点编程，释放算力潜能。我们希望协同 LlamaFactory 生态提供易用、高性能的分布式训练解决方案。我们的目标是让每一位开发者都能在 Ascend NPU 和 NVIDIA GPU 上高效训练大模型，降低大模型训练的门槛和成本。
+
+本路线图概述了 LlamaFactory 与 MindSpore HyperParallel 社区协作的发展方向，涵盖并行能力扩展、硬件优化、后端支持等多个维度。
+
+## 路线图总览
+
+```
+2026 Q2                    2026 Q3                    2026 Q4
+    │                          │                          │
+    ▼                          ▼                          ▼
+┌─────────────┐          ┌─────────────┐          ┌─────────────┐
+│  Phase 1    │          │  Phase 2    │          │  Phase 3    │
+│  能力扩展    │   ───►   │  硬件深化     │   ───►   │  后端多元    │
+└─────────────┘          └─────────────┘          └─────────────┘
+    │                          │                          │
+    ├─ TP/EP/CP混合并行         ├─ 高维TP等优化              ├─ MindSpore后端扩展
+    ├─ 更多模型泛化              ├─ HyperMPMD三层并行        ├─ 图算融合组件优化
+    └─ 更大模型规模              └─ HyperOffload UD链卸载    └─ 更多训练阶段支持
+```
+
+## Phase 1: 并行能力扩展 (2026 Q2)
+
+**目标**：扩展 TP（张量并行）/EP（专家并行）/CP（上下文并行）等多维混合并行能力，支持更大规模模型训练。
+
+| 特性 | 描述 | 优先级 | 状态 |
+|-----|------|-------|-----|
+| **TP-EP 混合并行** | 支持 MoE 模型的 TP+EP 组合并行策略 | P0 | 验证中 |
+| **CP 长序列支持** | 支持上下文并行，突破显存限制训练超长序列 | P0 | 验证中 |
+| **3D 并行 (DP-TP-PP)** | 完整的三维混合并行支持，适配千亿级参数模型 | P1 | 验证中 |
+| **昇腾亲和Offload策略** | 提供NPU亲和的多级智能显存卸载策略 | P2 | 开发中 |
+
+**技术要点**：
+- 统一的声明式并行策略配置接口
+- 高效的通信原语和调度算法
+- 昇腾亲和的并行和显存策略
+
+## Phase 2: 昇腾硬件深度优化 (2026 Q3)
+
+### 2.1 高维张量并行 (High-Dimensional TP)
+
+**目标**：扩展高维 TP 等昇腾亲和并行特性，提升 Atlas A5/A3/A2 上训练的效率和泛化性。
+
+| 特性 | 描述 | 硬件适配 | 预期收益 |
+|-----|------|---------|---------|
+| **2D-TP** | 双维张量并行，降低通信开销；TP 规模越大（≥8）收益越显著 | A5/A3 | 通信量减少 30%+（TP≥8 时更优） |
+| **TP-PP 混合** | TP+流水线并行组合 | A5/A3/A2 | 显存优化 20%+ |
+
+> **注**：高维 TP 的通信优化效果随 TP 并行度增大而愈加明显——当 TP≥8 时，传统 1D-TP 的 All-Reduce 通信量已成为显著瓶颈，2D-TP 通过将通信拆分到两个维度，通信量较 1D-TP 降低幅度可超过 40%。
+
+### 2.2 MPMD 多核并行优化 (HyperMPMD)
+
+**目标**：通过细粒度 MPMD（Multiple Program Multiple Data）并行，解决 MoE、多模态、强化学习等场景中的计算负载不均衡问题，充分利用昇腾超节点对等互联架构的协同能力。
+
+HyperMPMD 在三个维度上提供 MPMD 能力：
+
+**维度一：子模型内核级并发**
+
+利用昇腾 NPU 片上 AICube/AIVector 多核异构特性，在单卡内实现计算与通信的细粒度流水编排，解决 MoE 架构的通信掩盖难题。
+
+| 特性 | 描述 | 硬件适配 | 预期收益 |
+|-----|------|---------|---------|
+| **片内多核 MPMD** | AICube 负责矩阵运算，AIVector 负责通信前处理，两者并行流水 | A5/A3 | 通信掩盖率从 60% 提升至 **90%** |
+
+**维度二：子模型间并发均衡（Inter-sub-model Concurrency Balancing）**
+
+将模型中异构子模块（如多模态模型的文本/图像/音频编码器）解耦为独立并发子图任务，通过动态调度消除流水线气泡。
+
+**维度三：跨模型并发调度（Cross-model Concurrent Scheduling）**
+
+集成 MPMD 运行时的 Single Controller 模式，在超节点池化算力资源中实现模型级并发，适配强化学习的异步架构。
+
+**预估收益**：
+- 通信掩盖率从 **60% → 90%**
+- 消除多模态/MoE 场景 **10-40%** 流水线气泡
+- 整体训练性能提升约 **15%**，集群资源利用率提升 **15%+**
+
+### 2.3 智能显存卸载 (HyperOffload)
+
+**目标**：基于 Use-Definition（UD）链分析，将远端内存访问提升为计算图中的一等操作，实现确定性的全局显存规划与计算-通信重叠，充分释放超节点分层存储池的潜力。
+
+**技术方案**：HyperOffload 基于编译器的 Use-Definition 链对张量的定义点（Definition）与使用点（Use）进行全局生命周期分析，精确识别每个张量的最佳卸载/预取时机。突破了以往只针对权重（Weights）卸载的局限，实现了对训练推理全流程中 KV Cache、中间激活值（Activations）及优化器状态的深度分层管理。通过 UD 链驱动的统一逻辑视图，根据硬件拓扑自动感知 HBM 和 DDR 的带宽差异，将海量张量跨介质无缝调度。
+
+**预估收益**（基于 HyperOffload 论文实验数据）：
+
+*训练场景*：
+| 模型 | 硬件配置 | 基线 | + HyperOffload | 性能变化 |
+|-----|---------|------|----------------|---------|
+| LLaMA-8B | 8×Ascend 910C | 5.2s/step | 4.08s/step | **提升 ~20%** |
+| DeepSeek-V3 | 8×Ascend 910C | 2.5s/step | 2.19s/step | **提升 ~12%** |
+
+## Phase 3: MindSpore 后端支持 (2026 Q4)
+
+**目标**：LlamaFactory 官方支持 MindSpore 后端，使能 AKG、DVM 等 MindSpore 独有的深度图算融合优化能力，进一步释放昇腾 NPU 算力。
+
+## 社区协作计划
+
+### 与 LlamaFactory 社区的协作
+
+| 协作领域 | 具体内容 | 负责方 |
+|---------|---------|-------|
+| **代码集成** | LlamaFactory 官方支持 MindSpore 后端，集成 HyperParallel 并行能力 | 共建 |
+| **文档共建** | 在 LlamaFactory 官方文档中增加 MindSpore 后端使用指南 | 共建 |
+| **Issue 处理** | 建立联合 Issue 处理机制 | 共建 |
+| **版本同步** | 确保 HyperParallel 与 LlamaFactory 版本兼容性 | 共建 |
+
+## 联系我们
+
+- **MindSpore HyperParallel 仓库**: https://atomgit.com/mindspore/hyper-parallel
+- **MindSpore 官网**: https://www.mindspore.cn/
+- **MindSpore 社区**: https://gitcode.com/mindspore
+
+## 附录：术语表
+
+| 术语 | 全称 | 描述 |
+|-----|-----|-----|
+| TP | Tensor Parallelism | 张量并行 |
+| EP | Expert Parallelism | 专家并行 |
+| CP | Context Parallelism | 长序列并行 |
+| DP | Data Parallelism | 数据并行 |
+| PP | Pipeline Parallelism | 流水线并行 |
+| FSDP | Fully Sharded Data Parallel | 全分片数据并行 |
+| SPMD | Single Program Multiple Data | 单程序多数据并行 |
+| MPMD | Multiple Program Multiple Data | 多程序多数据并行 |
+| HCCL | Huawei Collective Communication Library | 华为集合通信库 |


### PR DESCRIPTION
## Summary
- Add MindSpore HyperParallel community collaboration roadmap blog post (bilingual: zh + en)
- Covers three phases: parallel capability expansion (Q2), Ascend hardware optimization (Q3), and MindSpore backend support (Q4)
- Introduces HyperMPMD multi-level MPMD parallelism and HyperOffload Use-Definition chain-based memory management

## Content
New bilingual blog posts:
- `content/posts/mindspore-hyperparallel-roadmap.zh.md` (Chinese)
- `content/posts/mindspore-hyperparallel-roadmap.en.md` (English)

Documenting the LlamaFactory x MindSpore HyperParallel collaboration roadmap, including:

- **Phase 1**: TP/EP/CP hybrid parallelism, Recompute, broader model generalization
- **Phase 2**: High-dimensional TP, HyperMPMD 3-level parallelism, HyperOffload Use-Definition chain-based hierarchical memory management
- **Phase 3**: MindSpore backend integration with AKG and graph-kernel fusion
- Community collaboration plan and terminology glossary